### PR TITLE
(Partial) Decoding png_xb1/bmp_xb1 Support

### DIFF
--- a/LibForge/LibForge/Texture/Texture.cs
+++ b/LibForge/LibForge/Texture/Texture.cs
@@ -12,6 +12,8 @@ namespace LibForge.Texture
       public int Width;
       public int Height;
       public int Flags;
+      public int DecompressedSize;
+      public int CompressionFlags;
       public byte[] Data;
     }
     public int Version;

--- a/LibForge/LibForge/Texture/TextureConverter.cs
+++ b/LibForge/LibForge/Texture/TextureConverter.cs
@@ -48,6 +48,11 @@ namespace LibForge.Texture
         // xb1 texture with mipmaps embedded
         DecodeDXT(m, imageData, true, true);
       }
+      else if (m.Data.Length >= (imageData.Length / 2))
+      {
+        // xb1 texture with mipmaps embedded
+        DecodeDXT(m, imageData, false, true);
+      }
       else
       {
         throw new Exception($"Don't know what to do with this texture (version={t.Version}, length={m.Data.Length}, imageLength={imageData.Length})");


### PR DESCRIPTION
- Mipmaps are embedded in the DDS texture itself. The 8 bytes of unknown data in the mipmap data in the header looks to be related to this feature + the zlib compression mentioned below.
- Some time around Rivals they started compressing textures with zlib.
- Textures are tiled/swizzled - assuming it's the same, or at the very least similar to 360. 

Currently the swizzling seems to be broken so I'm pushing this as a draft (and I don't know if this breaks decoding of version 6 or other textures). I just YOLO'd it with the framebuffer swizzling code from libxenon for testing and it made the result look more recognisable.